### PR TITLE
Make `MeshBuilder.fixNegativeSize()` also swap texture coordinates

### DIFF
--- a/kool-core/src/commonMain/kotlin/de/fabmax/kool/scene/geometry/MeshBuilder.kt
+++ b/kool-core/src/commonMain/kotlin/de/fabmax/kool/scene/geometry/MeshBuilder.kt
@@ -1110,10 +1110,14 @@ class RectProps {
         if (size.x < 0) {
             origin.x += size.x
             size.x = -size.x
+            texCoordUpperLeft.x = texCoordUpperRight.x.also { texCoordUpperRight.x = texCoordUpperLeft.x }
+            texCoordLowerLeft.x = texCoordLowerRight.x.also { texCoordLowerRight.x = texCoordLowerLeft.x }
         }
         if (size.y < 0) {
             origin.y += size.y
             size.y = -size.y
+            texCoordUpperLeft.y = texCoordLowerLeft.y.also { texCoordLowerLeft.y = texCoordUpperLeft.y }
+            texCoordUpperRight.y = texCoordLowerRight.y.also { texCoordLowerRight.y = texCoordUpperRight.y }
         }
     }
 


### PR DESCRIPTION
Currently, `MeshBuilder.fixNegativeSize()` swaps the vertex positions but not the texCoords, which is most likely not the expected behavior.